### PR TITLE
Renaming the 'HPOptimizer' class to 'HyperParamsOptimizer'

### DIFF
--- a/adelecv/api/optimize/segmentations/__init__.py
+++ b/adelecv/api/optimize/segmentations/__init__.py
@@ -1,9 +1,9 @@
 from .functional import get_hp_optimizers
-from .hp_optimizer import HPOptimizer
+from .hp_optimizer import HyperParamsOptimizer
 from .hyper_params import HyperParamsSegmentation
 
 __all__ = [
-    "HPOptimizer",
+    "HyperParamsOptimizer",
     "get_hp_optimizers",
     "HyperParamsSegmentation"
 ]

--- a/adelecv/api/optimize/segmentations/hp_optimizer.py
+++ b/adelecv/api/optimize/segmentations/hp_optimizer.py
@@ -37,7 +37,7 @@ def _log_study(study: Study) -> None:
         logger.info("%s: %s", key, value)
 
 
-class HPOptimizer:
+class HyperParamsOptimizer:
     """
     Class for hyperparams search and model training
 

--- a/adelecv/ui/dashboard/task/segmentation_task.py
+++ b/adelecv/ui/dashboard/task/segmentation_task.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from adelecv.api.data.segmentations import SegmentationDataset
 from adelecv.api.data.segmentations.types import DatasetType
-from adelecv.api.optimize.segmentations import (HPOptimizer,
+from adelecv.api.optimize.segmentations import (HyperParamsOptimizer,
                                                 HyperParamsSegmentation)
 
 from .base import BaseTask
@@ -18,7 +18,7 @@ class SegmentationTask(BaseTask):
                 int | float | str | list | tuple
             ]
     ) -> None:
-        self._hp_optimizer = HPOptimizer(
+        self._hp_optimizer = HyperParamsOptimizer(
             hyper_params=HyperParamsSegmentation(
                 architectures=params["architectures"],
                 encoders=params['encoders'],

--- a/docs/api.ipynb
+++ b/docs/api.ipynb
@@ -122,7 +122,7 @@
    "outputs": [],
    "source": [
     "from adelecv.api.optimize.segmentations import HyperParamsSegmentation\n",
-    "from adelecv.api.optimize.segmentations import HPOptimizer"
+    "from adelecv.api.optimize.segmentations import HyperParamsOptimizer"
    ],
    "metadata": {
     "collapsed": false
@@ -154,7 +154,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "hp_optimizer = HPOptimizer(\n",
+    "hp_optimizer = HyperParamsOptimizer(\n",
     "    hyper_params=params,\n",
     "    num_trials=1,\n",
     "    device='GPU',\n",

--- a/example/api.ipynb
+++ b/example/api.ipynb
@@ -244,7 +244,7 @@
    "outputs": [],
    "source": [
     "from adelecv.api.optimize.segmentations import HyperParamsSegmentation\n",
-    "from adelecv.api.optimize.segmentations import HPOptimizer"
+    "from adelecv.api.optimize.segmentations import HyperParamsOptimizer"
    ],
    "metadata": {
     "collapsed": false
@@ -294,7 +294,7 @@
     }
    ],
    "source": [
-    "hp_optimizer = HPOptimizer(\n",
+    "hp_optimizer = HyperParamsOptimizer(\n",
     "    hyper_params=params,\n",
     "    num_trials=3,\n",
     "    device='GPU',\n",


### PR DESCRIPTION
The proposed change is made to maintain terminological uniformity in the code. There are several references to the hyper-parameter entity in the project code base, for example, the 'HyperParamsSegmentation' class, so I would like to make a proposal at an early stage of the project to assign a unified designation to the hyper-parameter entity in the form of 'HyperParam' ('HyperParams' in the plural).